### PR TITLE
Actually using global state, configurable directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,27 @@ curl -v http://lb1.prod:13003/
 ```
 
 You should see the contents of `example.com` in your terminal.
+
+### Adding directives to upstreams
+
+You can add an additional config with `init_by_lua` directive to set up
+custom settings for zoidberg. Currently supported settings:
+
+#### Setting global directives for each upstream managed by zoidberg
+
+Add `keepalive 16;` to each `upstream` block:
+
+```lua
+ngx.shared.zoidberg:set("global_directives", "keepalive 16;")
+```
+
+#### Setting directives for specific upstreams managed by zoidberg
+
+Add `keepalive 8;` to upstream of `myapp`:
+
+```lua
+ngx.shared.zoidberg:set("upstream_directives:myapp", "keepalive 8;")
+```
+
+Note that setting global and local directives like `keepalive` would
+trigger an error since you cannot have two `keepalive` directives.

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,6 +10,7 @@ http {
     error_log /dev/stderr notice;
 
     # zoidberg thing
+    lua_shared_dict zoidberg 5m;
     server {
         listen %zoidberg_listen%;
 


### PR DESCRIPTION
It was possible to update zoidberg's view of cluster state only in one worker. Now state is updated globally and `GET /state` returns what was saved no matter what worker is answering. Upstreams were populated in each worker correctly.
