### PR TITLE
Enable version "1" by default with weight=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ curl -v http://lb1.prod:13003/
 
 You should see the contents of `example.com` in your terminal.
 
+### Default version
+
+Version `1` is automatically enabled with `weight` set to `1`. This allows
+you to skip version setting in the deployment process.
+
 ### Adding directives to upstreams
 
 You can add an additional config with `init_by_lua` directive to set up

--- a/lua/zoidberg-state-handler.lua
+++ b/lua/zoidberg-state-handler.lua
@@ -77,11 +77,15 @@ elseif ngx.req.get_method() == "PUT" or ngx.req.get_method() == "POST" then
 
         for _, server in ipairs(app.servers) do
             if state.state.versions[name] then
-                if state.state.versions[name][server.version].weight > 0 then
-                    local host = server.host
-                    local port = server.port
-                    local weight = state.state.versions[name][server.version].weight
-                    table.insert(directives, "server " .. host .. ":" .. port .. " weight=" .. weight .. ";")
+                if state.state.versions[name][server.version] then
+                    if state.state.versions[name][server.version].weight > 0 then
+                        local host = server.host
+                        local port = server.port
+                        local weight = state.state.versions[name][server.version].weight
+                        table.insert(directives, "server " .. host .. ":" .. port .. " weight=" .. weight .. ";")
+                    end
+                elseif server.version == "1" then
+                    table.insert(directives, "server " .. server.host .. ":" .. server.port .. " weight=1;")
                 end
             end
         end


### PR DESCRIPTION
Also fixed bug when lua crashed when servers were announced and version wasn't.

This enables simple deployments where there is no need to interact with zoidberg API.
