### PR TITLE
Prevent race confition on err usage

### DIFF
--- a/etc-nginx/lua/zoidberg.lua
+++ b/etc-nginx/lua/zoidberg.lua
@@ -276,6 +276,7 @@ end
 
 function _M.updateState(self, group, input)
   local state = stateFromInput(input)
+  local err
 
   for name, app in pairs(state) do
     err = self:updateApp(group, name, app)


### PR DESCRIPTION
__newindex(): writing a global Lua variable ('err') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
	.../zoidberg.lua:281: in function 'updateState'